### PR TITLE
Change PHP keywords to comply with PSR2

### DIFF
--- a/index.php
+++ b/index.php
@@ -166,7 +166,7 @@ $app->get('/:zip', function ($zip) {
 
         }
         // close the database connection
-        $db = NULL;
+        $db = null;
     }
     catch(PDOException $e)
     {


### PR DESCRIPTION
Hi, I've changed a PHP keyword to comply with [this standard](https://www.php-fig.org/psr/psr-2/#25-keywords-and-truefalsenull) in PSR2. It's admittedly a small fix but I hope it helps!